### PR TITLE
removed unused import of retry module & decorator in imageSourceMM.py

### DIFF
--- a/imageSourceMM.py
+++ b/imageSourceMM.py
@@ -4,7 +4,6 @@ from PIL import Image
 import time
 from Rectangle import Rectangle
 import wx
-from retry import retry
 
 class imageSource():
     
@@ -260,8 +259,7 @@ class imageSource():
         print "fw,fh",fw,fh
        
         return Rectangle(left,right,top,bottom)
-        
-    #@retry(tries= 5)
+
     def snap_image(self):
         #NEED TO IMPLEMENT IF NOT MICROMANAGER
         #with microscope in current configuration


### PR DESCRIPTION
No idea why I've got 4 commits here (bad git-kung-fu), just the two lines changed from your code.

 Also, happy to keep (and just install retry) if using retry will come up again in future!
